### PR TITLE
fix: Regex refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filenames and line numbers are now colored in the terminal if it supports it.
 - Hidden files are now supported properly on Windows.
 
+### Fixed in X.Y.Z
+
+- TODOs are no longer matched when starting in the middle of a comment line.
+
 ## [0.0.1] - 2023-05-15
 
 ### Added in 0.0.1

--- a/internal/scanner/comment.go
+++ b/internal/scanner/comment.go
@@ -16,8 +16,9 @@ package scanner
 
 // Comment is a generic Comment implementation.
 type Comment struct {
-	Text string
-	Line int
+	Text      string
+	Line      int
+	Multiline bool
 }
 
 // String implements fmt.Stringer.String.


### PR DESCRIPTION
Fixes bugs in TODO matches so they don't match todos that start in the middle of a comment.