### PR TITLE
feat: Add .todosignore file support.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,7 @@ linters-settings:
           - "github.com/ianlewis/todos"
 
           # Dependencies.
+          - "github.com/denormal/go-gitignore"
           - "github.com/fatih/color"
           - "github.com/google/go-github"
           - "github.com/ianlewis/linguist"

--- a/.todosignore
+++ b/.todosignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new `github-issue-reopener` binary was added. This tool will scan a
   directory for TODOs referencing a GitHub issue and reopen issues that have
   been prematurely closed.
+- Support for a `.todosignore` file was added. It functions the same as a
+  `.gitignore` file and uses the same format. Files matching the `.todosignore`
+  file are ignored when searching for TODOs.
 
 ## [0.2.0] - 2023-06-30
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ianlewis/todos
 go 1.20
 
 require (
+	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817
 	github.com/fatih/color v1.15.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v52 v52.0.0
@@ -19,6 +20,7 @@ require (
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-github/v53 v53.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,12 @@ github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod 
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/dayvonjersen/git4go v0.0.0-20150730160921-060dbfa3f1a1/go.mod h1:d4Czjd9u5QQ3gdds3c5TeNFtQdC5mrZzOqH3QHjmUIc=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 h1:0nsrg//Dc7xC74H/TZ5sYR8uk4UQRNjsw8zejqH5a4Q=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817/go.mod h1:C/+sI4IFnEpCn6VQ3GIPEp+FrQnQw+YQP3+n+GdGq7o=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -661,6 +661,57 @@ var testCases = []struct {
 			},
 		},
 	},
+	{
+		name: ".todosignore ignore file",
+		files: []*testutils.File{
+			{
+				Path:     ".todosignore",
+				Contents: []byte(`ignored.go`),
+				Mode:     0o600,
+			},
+			{
+				Path: "ignored.go",
+				Contents: []byte(`package foo
+				// package comment
+
+				// TODO is a function.
+				// TODO: some task.
+				func TODO() {
+					return // Random comment
+				}`),
+				Mode: 0o600,
+			},
+			{
+				Path: "line_comments.go",
+				Contents: []byte(`package foo
+				// package comment
+
+				// TODO is a function.
+				// TODO: some task.
+				func TODO() {
+					return // Random comment
+				}`),
+				Mode: 0o600,
+			},
+		},
+		opts: &Options{
+			Config: &todos.Config{
+				Types: []string{"TODO"},
+			},
+		},
+		expected: []*TODORef{
+			{
+				FileName: "line_comments.go",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "// TODO: some task.",
+					Message:     "some task.",
+					Line:        5,
+					CommentLine: 5,
+				},
+			},
+		},
+	},
 }
 
 type fixture struct {

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -712,6 +712,57 @@ var testCases = []struct {
 			},
 		},
 	},
+	{
+		name: ".todosignore ignore directory",
+		files: []*testutils.File{
+			{
+				Path:     ".todosignore",
+				Contents: []byte(`ignored/`),
+				Mode:     0o600,
+			},
+			{
+				Path: "ignored/ignored.go",
+				Contents: []byte(`package foo
+				// package comment
+
+				// TODO is a function.
+				// TODO: some task.
+				func TODO() {
+					return // Random comment
+				}`),
+				Mode: 0o600,
+			},
+			{
+				Path: "line_comments.go",
+				Contents: []byte(`package foo
+				// package comment
+
+				// TODO is a function.
+				// TODO: some task.
+				func TODO() {
+					return // Random comment
+				}`),
+				Mode: 0o600,
+			},
+		},
+		opts: &Options{
+			Config: &todos.Config{
+				Types: []string{"TODO"},
+			},
+		},
+		expected: []*TODORef{
+			{
+				FileName: "line_comments.go",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "// TODO: some task.",
+					Message:     "some task.",
+					Line:        5,
+					CommentLine: 5,
+				},
+			},
+		},
+	},
 }
 
 type fixture struct {


### PR DESCRIPTION
Fixes #125 

Adds support for a `.todosignore` file that works exactly the same way as the `.gitignore` and uses the same format.