### PR TITLE
fix: TypeScript detection

### DIFF
--- a/internal/scanner/config.go
+++ b/internal/scanner/config.go
@@ -68,7 +68,7 @@ var (
 		"Swift":         &SwiftConfig,
 		"SQL":           &SQLConfig,
 		"TOML":          &TOMLConfig,
-		"TypeScript":    &TypescriptConfig,
+		"TypeScript":    &TypeScriptConfig,
 		"Unix Assembly": &UnixAssemblyConfig,
 		"XML":           &XMLConfig,
 		"YAML":          &YAMLConfig,
@@ -275,8 +275,8 @@ var (
 	// TOMLConfig is a config for TOML.
 	TOMLConfig = ShellConfig
 
-	// TypescriptConfig is a config for Typescript.
-	TypescriptConfig = JavascriptConfig
+	// TypeScriptConfig is a config for Typescript.
+	TypeScriptConfig = JavascriptConfig
 
 	// UnixAssemblyConfig is a config for Unix Assembly.
 	UnixAssemblyConfig = AssemblyConfig

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -134,7 +134,11 @@ func FromBytes(fileName string, rawContents []byte, charset string) (*CommentSca
 	var lang string
 	// TODO(github.com/dayvonjersen/linguist/issues/13): Revert special case when TypeScript is detected properly.
 	if filepath.Ext(fileName) == ".ts" {
-		lang = "TypeScript"
+		// Try to detect if this is a Qt translation file (XML format).
+		lang = linguist.LanguageByContents(decodedContents, nil)
+		if lang != "XML" {
+			lang = "TypeScript"
+		}
 	} else {
 		lang = linguist.LanguageByContents(decodedContents, linguist.LanguageHints(fileName))
 	}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1308,6 +1308,19 @@ var loaderTestCases = []struct {
 		scanCharset:    "UTF-8",
 		expectedConfig: nil,
 	},
+	{
+		name: "typescript_is_not_xml.ts",
+		src: []byte(`
+			function wrapInArray(obj: string | string[]) {
+				if (typeof obj === "string") {
+					return [obj];
+				}
+				return obj;
+			}
+		`),
+		scanCharset:    "UTF-8",
+		expectedConfig: &TypeScriptConfig,
+	},
 }
 
 func TestFromFile(t *testing.T) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1321,6 +1321,22 @@ var loaderTestCases = []struct {
 		scanCharset:    "UTF-8",
 		expectedConfig: &TypeScriptConfig,
 	},
+	{
+		name: "qt_translation_file.ts",
+		src: []byte(`
+			<!DOCTYPE TS><TS>
+			<context>
+			    <name>QPushButton</name>
+			    <message>
+			        <source>Hello world!</source>
+			        <translation type="unfinished"></translation>
+			    </message>
+			</context>
+			</TS>		
+		`),
+		scanCharset:    "UTF-8",
+		expectedConfig: &XMLConfig,
+	},
 }
 
 func TestFromFile(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

linguist doesn't detect TypeScript files well so this PR adds specific detection for TypeScript files by their file extension.

**Related Issues:**

Fixes #513 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] A reference to a related issue in the repository.
  You are strongly encouraged to create an issue for any change to allow for
  discussion on the proposed change before actually making the changes and
  proposing them via a Pull Request.
- [x] A description of the changes proposed in the pull request.
- [x] Please make sure to sign the
      [Google CLA](https://cla.developers.google.com/about/google-corporate).
- [x] Please make sure your commits include a
      [Developer Certificate of Origin](https://developercertificate.org/)
      signoff.
  ```text
  This is my commit message
  Signed-off-by: Random J Developer <random@developer.example.org>
  ```
- [x] Please add unit tests