### PR TITLE
feat: Add support for looser TODO special case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new `--charset` flag was added which defaults to `UTF-8`. This is the
   character set used to read the code files. A special name of `detect`
   specifies that the character set of each file should be detected.
+- Support was added for TODO comments with no space between the comment start
+  and "TODO" marker and no delimiter.
+
+  ```go
+  //TODO Add some code here.
+  ```
 
 ### Changed
 

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -520,6 +520,98 @@ func TestTODOScanner(t *testing.T) {
 			},
 			expected: nil,
 		},
+		"special_case_todo_naked.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "//TODO",
+						Line: 1,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "//TODO",
+					Label:       "",
+					Message:     "",
+					Line:        1,
+					CommentLine: 1,
+				},
+			},
+		},
+		"special_case_todo_with_message.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "//TODO Add some useful code here.",
+						Line: 1,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "//TODO Add some useful code here.",
+					Label:       "",
+					Message:     "Add some useful code here.",
+					Line:        1,
+					CommentLine: 1,
+				},
+			},
+		},
+		"special_case_todo_with_label.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "//TODO(github.com/foo/bar/issues/1) Add some useful code here.",
+						Line: 1,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "//TODO(github.com/foo/bar/issues/1) Add some useful code here.",
+					Label:       "github.com/foo/bar/issues/1",
+					Message:     "Add some useful code here.",
+					Line:        1,
+					CommentLine: 1,
+				},
+			},
+		},
+		"special_case_todo_no_message.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "//TODO(github.com/foo/bar/issues/1)",
+						Line: 1,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "//TODO(github.com/foo/bar/issues/1)",
+					Label:       "github.com/foo/bar/issues/1",
+					Message:     "",
+					Line:        1,
+					CommentLine: 1,
+				},
+			},
+		},
 		"multiline_comments_leading_whitespace.go": {
 			s: &testScanner{
 				comments: []*scanner.Comment{


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Adds support for a special case of TODO comments with no whitespace between the comment start and "TODO" and with no delimiter between "TODO" and the message.

```text
//TODO This is a todo comment.
```

**Related Issues:**

Fixes #514 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] A reference to a related issue in the repository.
- [x] A description of the changes proposed in the pull request.
- [x] Please make sure to sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
- [x] Please make sure your commits include a [Developer Certificate of Origin](https://developercertificate.org/) signoff.
- [x] Please add unit tests
