### PR TITLE
feat: Add support for TODOs in JavaDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#p Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+#p Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   ```go
   //TODO Add some code here.
+  ```
+
+- Support was added for TODO comments in JavaDoc/JSDoc/TSDoc that had a `*`
+  prefix.
+
+  ```java
+  /**
+   * Some comment.
+   * TODO: Add some code here.
+   */
   ```
 
 ### Changed

--- a/internal/todos/todos.go
+++ b/internal/todos/todos.go
@@ -137,7 +137,7 @@ func NewTODOScanner(s CommentScanner, config *Config) *TODOScanner {
 		regexp.MustCompile(`^\s*(` + commentStartMatch + `)\s*(` + typesMatch + `)(` + msgMatch + `)$`),
 		regexp.MustCompile(`^\s*(` + commentStartMatch + `)(` + typesMatch + `)(` + msgMatch2 + `)$`),
 	}
-	snr.multilineMatch = regexp.MustCompile(`^(` + multiStartMatch + `)?\s*(` + typesMatch + `)(` + msgMatch + `)$`)
+	snr.multilineMatch = regexp.MustCompile(`^(` + multiStartMatch + `\s*|\s*\*?\s*)?(` + typesMatch + `)(` + msgMatch + `)$`)
 
 	return snr
 }

--- a/internal/todos/todos.go
+++ b/internal/todos/todos.go
@@ -137,7 +137,8 @@ func NewTODOScanner(s CommentScanner, config *Config) *TODOScanner {
 		regexp.MustCompile(`^\s*(` + commentStartMatch + `)\s*(` + typesMatch + `)(` + msgMatch + `)$`),
 		regexp.MustCompile(`^\s*(` + commentStartMatch + `)(` + typesMatch + `)(` + msgMatch2 + `)$`),
 	}
-	snr.multilineMatch = regexp.MustCompile(`^(` + multiStartMatch + `\s*|\s*\*?\s*)?(` + typesMatch + `)(` + msgMatch + `)$`)
+	snr.multilineMatch = regexp.MustCompile(
+		`^(` + multiStartMatch + `\s*|\s*\*?\s*)?(` + typesMatch + `)(` + msgMatch + `)$`)
 
 	return snr
 }

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -488,7 +488,7 @@ func TestTODOScanner(t *testing.T) {
 					},
 					{
 						Text: "// godoc ",
-						Line: 7,
+						Line: 9,
 					},
 				},
 			},
@@ -499,6 +499,38 @@ func TestTODOScanner(t *testing.T) {
 				{
 					Type:        "TODO",
 					Text:        "TODO(github.com/foo/bar/issues1): foo",
+					Label:       "github.com/foo/bar/issues1",
+					Message:     "foo",
+					Line:        7,
+					CommentLine: 5,
+				},
+			},
+		},
+		"multiline_comments_javadoc.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "// package comment",
+						Line: 1,
+					},
+					{
+						Text:      "/**\n * foo\n * TODO(github.com/foo/bar/issues1): foo\n */",
+						Line:      5,
+						Multiline: true,
+					},
+					{
+						Text: "// javadoc ",
+						Line: 9,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "* TODO(github.com/foo/bar/issues1): foo",
 					Label:       "github.com/foo/bar/issues1",
 					Message:     "foo",
 					Line:        7,


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Add support for JavaDoc/JSDoc/TSDoc comments that have a leading asterisk.

```java
/**
 * Some comment.
 * TODO: Add some code here.
 */
```

**Related Issues:**

Fixes #517 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
