### PR TITLE
refactor: Detect language by filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The language of each file is now determined by it's file name in most
+  circumstances allowing for much faster language detection.
+
 ## [0.5.0] - 2023-09-04
 
 ### Added in 0.5.0

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -145,7 +145,11 @@ func FromBytes(fileName string, rawContents []byte, charset string) (*CommentSca
 			lang = "TypeScript"
 		}
 	} else {
-		lang = linguist.LanguageByContents(decodedContents, linguist.LanguageHints(fileName))
+		lang = linguist.LanguageByFilename(fileName)
+		fmt.Printf("%s %q\n", fileName, lang)
+		if lang == "" {
+			lang = linguist.LanguageByContents(decodedContents, linguist.LanguageHints(fileName))
+		}
 	}
 	if lang == "" {
 		return nil, nil

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -146,7 +146,6 @@ func FromBytes(fileName string, rawContents []byte, charset string) (*CommentSca
 		}
 	} else {
 		lang = linguist.LanguageByFilename(fileName)
-		fmt.Printf("%s %q\n", fileName, lang)
 		if lang == "" {
 			lang = linguist.LanguageByContents(decodedContents, linguist.LanguageHints(fileName))
 		}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Detect the language of each file based on it's file name if able. This makes language detection much faster since the file contents do not need to be read.

**Related Issues:**

Fixes #518 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
