### PR TITLE
fix: report all TODOs in a multi-line comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- All TODOs in a multi-line comment are now reported (#721).
+- All TODOs in a multi-line comment are now reported
+  ([#721](https://github.com/ianlewis/todos/pull/721)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for CoffeeScript was added.
 
+### Fixed
+
+- All TODOs in a multi-line comment are now reported (#721).
+
 ### Changed
 
 - The language of each file is now determined by it's file name in most

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -508,6 +508,46 @@ func TestTODOScanner(t *testing.T) {
 				},
 			},
 		},
+		"multiline_comments_multiple_todos.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "// package comment",
+						Line: 1,
+					},
+					{
+						Text:      "/*\nfoo\nTODO(github.com/foo/bar/issues1): foo\nTODO: second task\n */",
+						Line:      5,
+						Multiline: true,
+					},
+					{
+						Text: "// godoc ",
+						Line: 9,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "TODO(github.com/foo/bar/issues1): foo",
+					Label:       "github.com/foo/bar/issues1",
+					Message:     "foo",
+					Line:        7,
+					CommentLine: 5,
+				},
+				{
+					Type:        "TODO",
+					Text:        "TODO: second task",
+					Label:       "",
+					Message:     "second task",
+					Line:        8,
+					CommentLine: 5,
+				},
+			},
+		},
 		"multiline_comments_javadoc.go": {
 			s: &testScanner{
 				comments: []*scanner.Comment{


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Updates the TODO parser to report all TODOs in a multi-line comment.

**Related Issues:**

Fixes #709 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
