### PR TITLE
feat: Support `@` prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for [Clojure](https://clojure.org/) and
   [CoffeeScript](https://coffeescript.org/) were added.
+- Support for an `@` prefix on TODOs was added.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ In order for the comments to be more easily parsed keep in mind the following:
 - Spaces between the comment start and 'TODO' is optional (e.g. `//TODO: some comment`)
 - TODOs should have a colon if a message is present so it can be distingished
   from normal comments.
+- TODOs can be prefixed with `@` (e.g. `// @TODO: comment`)
 - Comments can be on the same line with other code (e.g. `x = f() // TODO: call f`
 - Line comment start sequences can be repeated (e.g. `//// TODO: some comment`)
 - Only the single line where the TODO occurs is printed for multi-line comments.

--- a/internal/todos/todos.go
+++ b/internal/todos/todos.go
@@ -134,11 +134,11 @@ func NewTODOScanner(s CommentScanner, config *Config) *TODOScanner {
 	}, "|")
 
 	snr.lineMatch = []*regexp.Regexp{
-		regexp.MustCompile(`^\s*(` + commentStartMatch + `)\s*(` + typesMatch + `)(` + msgMatch + `)$`),
-		regexp.MustCompile(`^\s*(` + commentStartMatch + `)(` + typesMatch + `)(` + msgMatch2 + `)$`),
+		regexp.MustCompile(`^\s*(` + commentStartMatch + `)\s*@?(` + typesMatch + `)(` + msgMatch + `)$`),
+		regexp.MustCompile(`^\s*(` + commentStartMatch + `)@?(` + typesMatch + `)(` + msgMatch2 + `)$`),
 	}
 	snr.multilineMatch = regexp.MustCompile(
-		`^(` + multiStartMatch + `\s*|\s*\*?\s*)?(` + typesMatch + `)(` + msgMatch + `)$`)
+		`^(` + multiStartMatch + `\s*|\s*\*?\s*)?@?(` + typesMatch + `)(` + msgMatch + `)$`)
 
 	return snr
 }

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -741,6 +741,76 @@ func TestTODOScanner(t *testing.T) {
 				},
 			},
 		},
+		"at_prefix.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "// @TODO: comment",
+						Line: 1,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "// @TODO: comment",
+					Label:       "",
+					Message:     "comment",
+					Line:        1,
+					CommentLine: 1,
+				},
+			},
+		},
+		"at_prefix_alt.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "//@TODO comment",
+						Line: 1,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "//@TODO comment",
+					Label:       "",
+					Message:     "comment",
+					Line:        1,
+					CommentLine: 1,
+				},
+			},
+		},
+		"at_prefix_multiline.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text:      "/**\n * @TODO: comment\n */",
+						Line:      1,
+						Multiline: true,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "* @TODO: comment",
+					Label:       "",
+					Message:     "comment",
+					Line:        2,
+					CommentLine: 1,
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Adds support for `@` prefix on TODOs ala the old JavaDoc style.

e.g.
```java
/**
 * @todo: foo
 */
```

**Related Issues:**

Fixes #516 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
