### PR TITLE
fix: panic when no matches occur in multi-line comment

### DIFF
--- a/internal/todos/todos.go
+++ b/internal/todos/todos.go
@@ -158,7 +158,7 @@ func (t *TODOScanner) Scan() bool {
 		if next.Multiline {
 			matches := t.findMultilineMatches(next)
 			t.next = append(t.next, matches...)
-			return true
+			return len(t.next) > 0
 		}
 
 		match := t.findLineMatch(next)

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -508,7 +508,7 @@ func TestTODOScanner(t *testing.T) {
 				},
 			},
 		},
-		"multiline_comments_multiple_todos.go": {
+		"multiline_comments_no_todo.go": {
 			s: &testScanner{
 				comments: []*scanner.Comment{
 					{
@@ -516,7 +516,7 @@ func TestTODOScanner(t *testing.T) {
 						Line: 1,
 					},
 					{
-						Text:      "/*\nfoo\nTODO(github.com/foo/bar/issues1): foo\nTODO: second task\n */",
+						Text:      "/*\nfoo\nfoo\n*/",
 						Line:      5,
 						Multiline: true,
 					},
@@ -529,7 +529,47 @@ func TestTODOScanner(t *testing.T) {
 			config: &Config{
 				Types: []string{"TODO"},
 			},
+			expected: nil,
+		},
+
+		"multiline_comments_multiple_todos.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "// package comment",
+						Line: 1,
+					},
+					{
+						Text: "// TODO: before",
+						Line: 2,
+					},
+					{
+						Text:      "/*\nfoo\nTODO(github.com/foo/bar/issues1): foo\nTODO: second task\n */",
+						Line:      5,
+						Multiline: true,
+					},
+					{
+						Text: "// godoc ",
+						Line: 9,
+					},
+					{
+						Text: "// TODO: after",
+						Line: 10,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
 			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "// TODO: before",
+					Label:       "",
+					Message:     "before",
+					Line:        2,
+					CommentLine: 2,
+				},
 				{
 					Type:        "TODO",
 					Text:        "TODO(github.com/foo/bar/issues1): foo",
@@ -545,6 +585,14 @@ func TestTODOScanner(t *testing.T) {
 					Message:     "second task",
 					Line:        8,
 					CommentLine: 5,
+				},
+				{
+					Type:        "TODO",
+					Text:        "// TODO: after",
+					Label:       "",
+					Message:     "after",
+					Line:        10,
+					CommentLine: 10,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Fixes panic when no matches occur in multi-line comment.

**Related Issues:**

Fixes #776 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
