### PR TITLE
chore: Update clean make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,4 +172,9 @@ yamllint: ## Runs the yamllint linter.
 
 .PHONY: clean
 clean: ## Delete temporary files.
-	rm -rf vendor node_modules
+	rm -rf vendor node_modules coverage.out
+	@set -e;\
+		PATHS=$$(find actions/ -not -path '*/node_modules/*' -name package.json -type f | xargs dirname); \
+		for path in $$PATHS; do \
+			make -C $$path clean; \
+		done

--- a/actions/issue-reopener/Makefile
+++ b/actions/issue-reopener/Makefile
@@ -40,15 +40,17 @@ node_modules/.installed: package.json package-lock.json
 
 .PHONY: action
 action: node_modules/.installed ## Builds the action.
+	rm -rf lib
 	npm run build
 
 .PHONY: package
 package: action ## Builds the distribution package.
+	rm -rf dist
 	npm run package
 
 .PHONY: clean
 clean:
-	rm -rf dist lib node_modules
+	rm -rf lib node_modules coverage
 
 ## Tools
 #####################################################################


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Updates the clean makefile target so that it doesn't delete files in the `dist` directory for Github Actions. The main `clean` target also runs `make clean` for GitHub Actions as well as for the main Go code.

**Related Issues:**

N/A

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
