### PR TITLE
feat: Support multi-line comments at line start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for [Emacs Lisp](https://www.gnu.org/software/emacs/) was added.
+- Support for recognizing multi-line comments only at the beginning of a line
+  (Ruby, Perl) was added.
 
 ## [0.6.0] - 2023-09-23
 

--- a/internal/scanner/languages.go
+++ b/internal/scanner/languages.go
@@ -26,8 +26,9 @@ var languagesRaw []byte
 
 // MultilineCommentConfig describes multi-line comments.
 type MultilineCommentConfig struct {
-	Start string `yaml:"start,omitempty"`
-	End   string `yaml:"end,omitempty"`
+	Start       string `yaml:"start,omitempty"`
+	End         string `yaml:"end,omitempty"`
+	AtLineStart bool   `yaml:"at_line_start,omitempty"`
 }
 
 var (

--- a/internal/scanner/languages.yml
+++ b/internal/scanner/languages.yml
@@ -243,10 +243,10 @@ Objective-C:
       escape: backslash
 Perl:
   line_comment_start: ["#"]
-  # TODO(#665): = must be at the start of a line.
-  # multiline_comment:
-  #   start: "="
-  #   end: "=cut"
+  multiline_comment:
+    start: "="
+    end: "=cut"
+    at_line_start: true
   strings:
     # TODO(#357): Perl supports strings with any delimiter.
     - start: '"'
@@ -291,9 +291,9 @@ R:
 Ruby:
   line_comment_start: ["#"]
   multiline_comment:
-    # TODO(#665): = must be at the start of a line.
     start: "=begin"
     end: "=end"
+    at_line_start: true
   strings:
     - start: '"'
       end: '"'

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1208,6 +1208,102 @@ var scannerTestCases = []*struct {
 			},
 		},
 	},
+	{
+		name: "multi_line.rs",
+		src: `# file comment
+
+=begin
+TODO is a function.
+=end
+
+			def foo()
+				# Random comment
+				x = "\"# Random comment x"
+				y = '\'# Random comment y'
+				return x + y
+			end`,
+		config: "Ruby",
+		comments: []struct {
+			text string
+			line int
+		}{
+			{
+				text: "# file comment",
+				line: 1,
+			},
+			{
+				text: "=begin\nTODO is a function.\n=end",
+				line: 3,
+			},
+			{
+				text: "# Random comment",
+				line: 8,
+			},
+		},
+	},
+	{
+		name: "multi_line_not_line_start.rs",
+		src: `# file comment
+
+	=begin
+TODO is a function.
+=end
+
+			def foo()
+				# Random comment
+				x = "\"# Random comment x"
+				y = '\'# Random comment y'
+				return x + y
+			end`,
+		config: "Ruby",
+		comments: []struct {
+			text string
+			line int
+		}{
+			{
+				text: "# file comment",
+				line: 1,
+			},
+			{
+				text: "# Random comment",
+				line: 8,
+			},
+		},
+	},
+	{
+		name: "multi_line_end.rs",
+		src: `# file comment
+
+=begin
+TODO is a function.
+	=end
+=end
+
+			def foo()
+				# Random comment
+				x = "\"# Random comment x"
+				y = '\'# Random comment y'
+				return x + y
+			end`,
+		config: "Ruby",
+		comments: []struct {
+			text string
+			line int
+		}{
+			{
+				text: "# file comment",
+				line: 1,
+			},
+			{
+				text: "=begin\nTODO is a function.\n\t=end\n=end",
+				line: 3,
+			},
+			{
+				text: "# Random comment",
+				line: 9,
+			},
+		},
+	},
 
 	// Rust
 	{


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Add support for recognizing the multi-line comments that only begin at the start of a line.

**Related Issues:**

Fixes #665 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
