### PR TITLE
fix: benchmarks now run multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 SHELL := /bin/bash
 OUTPUT_FORMAT ?= $(shell if [ "${GITHUB_ACTIONS}" == "true" ]; then echo "github"; else echo ""; fi)
 
+BENCHTIME ?= 1s
+TESTCOUNT ?= 1
+
 .PHONY: help
 help: ## Shows all targets and help from the Makefile (this message).
 	@echo "todos Makefile"
@@ -71,7 +74,7 @@ go-benchmark: ## Runs Go benchmarks.
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
 			extraargs="-v"; \
 		fi; \
-		go test $$extraargs -bench=. -run=^# ./...
+		go test $$extraargs -bench=. -count=$(TESTCOUNT) -benchtime=$(BENCHTIME) -run='^#' ./...
 
 ## Tools
 #####################################################################

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1294,7 +1294,7 @@ var scannerTestCases = []*struct {
 		},
 	},
 	{
-		name: "multi_line.rs",
+		name: "multi_line.rb",
 		src: `# file comment
 
 =begin
@@ -1327,7 +1327,7 @@ TODO is a function.
 		},
 	},
 	{
-		name: "multi_line_not_line_start.rs",
+		name: "multi_line_not_line_start.rb",
 		src: `# file comment
 
 	=begin
@@ -1356,7 +1356,7 @@ TODO is a function.
 		},
 	},
 	{
-		name: "multi_line_end.rs",
+		name: "multi_line_end.rb",
 		src: `# file comment
 
 =begin
@@ -1905,8 +1905,10 @@ func BenchmarkCommentScanner(b *testing.B) {
 	for i := range scannerTestCases {
 		tc := scannerTestCases[i]
 		b.Run(tc.name, func(b *testing.B) {
-			s := New(strings.NewReader(tc.src), LanguagesConfig[tc.config])
-			for s.Scan() {
+			for i := 0; i < b.N; i++ {
+				s := New(strings.NewReader(tc.src), LanguagesConfig[tc.config])
+				for s.Scan() {
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Fix benchmarks so that they run multiple times in a loop. This allows them to be timed properly.

**Related Issues:**

Updates #45 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
