### PR TITLE
ci: Add -s -w ldflags to release

### DIFF
--- a/.slsa-goreleaser/todos-darwin-amd64.yml
+++ b/.slsa-goreleaser/todos-darwin-amd64.yml
@@ -44,4 +44,4 @@ binary: todos-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"
+  - "-s -w -X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"

--- a/.slsa-goreleaser/todos-darwin-arm64.yml
+++ b/.slsa-goreleaser/todos-darwin-arm64.yml
@@ -44,4 +44,4 @@ binary: todos-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"
+  - "-s -w -X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"

--- a/.slsa-goreleaser/todos-linux-amd64.yml
+++ b/.slsa-goreleaser/todos-linux-amd64.yml
@@ -44,4 +44,4 @@ binary: todos-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"
+  - "-s -w -X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"

--- a/.slsa-goreleaser/todos-linux-arm64.yml
+++ b/.slsa-goreleaser/todos-linux-arm64.yml
@@ -44,4 +44,4 @@ binary: todos-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"
+  - "-s -w -X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"

--- a/.slsa-goreleaser/todos-windows-amd64.yml
+++ b/.slsa-goreleaser/todos-windows-amd64.yml
@@ -44,4 +44,4 @@ binary: todos-{{ .Os }}-{{ .Arch }}.exe
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"
+  - "-s -w -X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"

--- a/.slsa-goreleaser/todos-windows-arm64.yml
+++ b/.slsa-goreleaser/todos-windows-arm64.yml
@@ -44,4 +44,4 @@ binary: todos-{{ .Os }}-{{ .Arch }}.exe
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"
+  - "-s -w -X sigs.k8s.io/release-utils/version.gitVersion={{ .Env.VERSION }}"


### PR DESCRIPTION
**Description:**

Add -s -w ldflags to SLSA builder config so that release binaries have debug symbols stripped. This results in smaller binaries.

**Related Issues:**

Fixes #1082

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
