### PR TITLE
fix: update todo-issue-reopener hash

### DIFF
--- a/.github/workflows/schedule.issue-reopener.yml
+++ b/.github/workflows/schedule.issue-reopener.yml
@@ -27,4 +27,4 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Issue Reopener
-        uses: ianlewis/todo-issue-reopener@cc16e43c6292f1c3c7f67a3d9027e05967a59b79 # v0.1.0
+        uses: ianlewis/todo-issue-reopener@4a773af3fd25a77e0622a689e5fd208c28fb4fba # v0.1.0


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Updates the hash for todo-issue-reopener to the correct value.

**Related Issues:**

Updates #1367 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
