### PR TITLE
fix: default output to github on GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for [Kotlin](https://kotlinlang.org/) was added.
 
+### Fixed
+
+- The `--output` flag defaults to `github` when `todos` is run on GitHub
+  Actions (#1459).
+
 ### Removed
 
 - The `action/issue-reopener` GitHub Action was removed in favor of the

--- a/internal/cmd/todos/app.go
+++ b/internal/cmd/todos/app.go
@@ -76,6 +76,12 @@ func init() {
 
 // newTODOsApp returns a new `todos` application.
 func newTODOsApp() *cli.App {
+	defaultOutput := "default"
+	gha := os.Getenv("GITHUB_ACTIONS")
+	if gha == "true" {
+		defaultOutput = "github"
+	}
+
 	return &cli.App{
 		Name:  filepath.Base(os.Args[0]),
 		Usage: "Search for TODOS in code.",
@@ -117,7 +123,7 @@ func newTODOsApp() *cli.App {
 			&cli.StringFlag{
 				Name:    "output",
 				Usage:   "output `TYPE` (default, github, json)",
-				Value:   "default",
+				Value:   defaultOutput,
 				Aliases: []string{"o"},
 			},
 			&cli.BoolFlag{


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Default the `--output` flag to `github` when `GITHUB_ACTIONS` is `true` for ease of use on GitHub Actions.

**Related Issues:**

Fixes #1459

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
