### PR TITLE
fix: exclude-dir not matching with path separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for [Kotlin](https://kotlinlang.org/) was added.
 
+### Fixed
+
+- The `--exclude-dir` option now ignores trailing path separators (#1463)
+
 ### Removed
 
 - The `action/issue-reopener` GitHub Action was removed in favor of the

--- a/internal/cmd/todos/app.go
+++ b/internal/cmd/todos/app.go
@@ -306,7 +306,7 @@ func walkerOptionsFromContext(c *cli.Context) (*walker.Options, error) {
 	}
 
 	for _, gs := range c.StringSlice("exclude-dir") {
-		g, err := glob.Compile(gs)
+		g, err := glob.Compile(strings.TrimRight(gs, string(os.PathSeparator)))
 		if err != nil {
 			return nil, fmt.Errorf("%w: exclude-dir: %w", ErrFlagParse, err)
 		}

--- a/internal/cmd/todos/app_test.go
+++ b/internal/cmd/todos/app_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
+	"os"
 	"strings"
 	"testing"
 
@@ -489,6 +490,18 @@ func Test_walkerOptionsFromContext(t *testing.T) {
 				Charset:         defaultCharset,
 				IncludeHidden:   true,
 				ExcludeDirGlobs: []glob.Glob{glob.MustCompile("exclude?"), glob.MustCompile("foo")},
+				Paths:           []string{"."},
+			},
+		},
+		"exclude-dir-pathsep": {
+			args: []string{"--exclude-dir=exclude" + string(os.PathSeparator)},
+			expected: &walker.Options{
+				Config: &todos.Config{
+					Types: todos.DefaultTypes,
+				},
+				Charset:         defaultCharset,
+				IncludeHidden:   true,
+				ExcludeDirGlobs: []glob.Glob{glob.MustCompile("exclude")},
 				Paths:           []string{"."},
 			},
 		},


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

`--exclude-dir` now ignores trailing path separators on the directory name passed to it. This is since it's natural to pass something like `mydir/` as a directory name.

**Related Issues:**

Fixes #1463

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
