### PR TITLE
feat: Ignore generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for [Fortran](https://fortran-lang.org/) was added.
+- Generated files are now ignored by default. The option `--include-generated`
+  was added to allow generated files to be scanned for TODOs.
 
 ## [0.8.0] - 2024-02-21
 

--- a/internal/cmd/todos/app.go
+++ b/internal/cmd/todos/app.go
@@ -111,8 +111,15 @@ func newTODOsApp() *cli.App {
 				DisableDefaultText: true,
 			},
 			&cli.BoolFlag{
+				Name:               "include-generated",
+				Usage:              "include generated files",
+				Value:              false,
+				DisableDefaultText: true,
+			},
+			&cli.BoolFlag{
 				Name:               "include-vendored",
 				Usage:              "include vendored directories",
+				Value:              false,
 				DisableDefaultText: true,
 			},
 			&cli.StringFlag{
@@ -319,6 +326,7 @@ func walkerOptionsFromContext(c *cli.Context) (*walker.Options, error) {
 		o.ExcludeDirGlobs = append(o.ExcludeDirGlobs, g)
 	}
 
+	o.IncludeGenerated = c.Bool("include-generated")
 	o.IncludeHidden = !c.Bool("exclude-hidden")
 	o.IncludeVCS = c.Bool("include-vcs")
 	o.IncludeVendored = c.Bool("include-vendored")


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Ignore generated files by default. A new option `--include-generated` overrides this behavior.

**Related Issues:**

Fixes #1506

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
