### PR TITLE
fix: TODO comments after multi-line comments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a bug where TODOs were not being reported if they were located after a
+  multi-line comment with no TODOs in the same file
+  ([#1520](https://github.com/ianlewis/todos/issues/1520))
+
 ## [0.9.0-rc.2] - 2024-07-17
 
 ### Added in 0.9.0-rc.2

--- a/internal/todos/todos.go
+++ b/internal/todos/todos.go
@@ -158,13 +158,15 @@ func (t *TODOScanner) Scan() bool {
 		if next.Multiline {
 			matches := t.findMultilineMatches(next)
 			t.next = append(t.next, matches...)
-			return len(t.next) > 0
-		}
-
-		match := t.findLineMatch(next)
-		if match != nil {
-			t.next = append(t.next, match)
-			return true
+			if len(t.next) > 0 {
+				return true
+			}
+		} else {
+			match := t.findLineMatch(next)
+			if match != nil {
+				t.next = append(t.next, match)
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -859,6 +859,37 @@ func TestTODOScanner(t *testing.T) {
 				},
 			},
 		},
+		// Regression test for issue #1520
+		// Ensure that the TODOScanner continues scanning after finding a
+		// multi-line comment with no TODOs in it.
+		"regression_1520.go": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text:      "/**\n no match here\n */",
+						Line:      1,
+						Multiline: true,
+					},
+					{
+						Text: "// TODO: match",
+						Line: 5,
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"TODO"},
+			},
+			expected: []*TODO{
+				{
+					Type:        "TODO",
+					Text:        "// TODO: match",
+					Label:       "",
+					Message:     "match",
+					Line:        5,
+					CommentLine: 5,
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
**Description:**

Fixes an issue where the `TODOScanner.Scan` would return `false` if it encounters a multi-line comment with no TODOs present in it.

**Related Issues:**

Fixes #1520

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
