### PR TITLE
fix: Fix relative paths to git repo for git blame paths

### DIFF
--- a/internal/testutils/gitrepo.go
+++ b/internal/testutils/gitrepo.go
@@ -23,17 +23,18 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
-// TempRepo is a repo created in a temporary directory.
-type TempRepo struct {
+// TestRepo is a repo created in a temporary directory.
+type TestRepo struct {
 	dir  string
 	repo *git.Repository
 }
 
-// NewTempRepo creates a new TempRepo with the given files committed into a
+// NewTestRepo creates a new TestRepo with the given files committed into a
 // single commit in the repo.
-func NewTempRepo(author, email string, files []*File) *TempRepo {
-	r := &TempRepo{}
-	r.dir = Must(os.MkdirTemp("", "testutils"))
+func NewTestRepo(dir, author, email string, files []*File) *TestRepo {
+	r := &TestRepo{
+		dir: dir,
+	}
 
 	r.repo = Must(git.PlainInit(r.dir, false))
 
@@ -67,16 +68,11 @@ func NewTempRepo(author, email string, files []*File) *TempRepo {
 }
 
 // Dir returns the path to the repo root directory.
-func (r *TempRepo) Dir() string {
+func (r *TestRepo) Dir() string {
 	return r.dir
 }
 
 // Repository returns the git repository.
-func (r *TempRepo) Repository() *git.Repository {
+func (r *TestRepo) Repository() *git.Repository {
 	return r.repo
-}
-
-// Cleanup deletes the test repository.
-func (r *TempRepo) Cleanup() {
-	Check(os.RemoveAll(r.dir))
 }

--- a/internal/testutils/gitrepo_test.go
+++ b/internal/testutils/gitrepo_test.go
@@ -142,11 +142,11 @@ func TestTempRepo(t *testing.T) {
 				}
 			}()
 
-			d := NewTempRepo(tc.author, tc.email, tc.files)
+			tmpDir := NewTempDir(nil)
+			defer tmpDir.Cleanup()
+
+			d := NewTestRepo(tmpDir.Dir(), tc.author, tc.email, tc.files)
 			baseDir := d.Dir()
-			defer func() {
-				_ = os.RemoveAll(baseDir)
-			}()
 
 			// Check that the temporary directory exists.
 			checkDir(t, baseDir)
@@ -178,11 +178,6 @@ func TestTempRepo(t *testing.T) {
 				if diff := cmp.Diff(want, got); diff != "" {
 					t.Errorf("unexpected contents: (-want, +got): %s", diff)
 				}
-			}
-
-			d.Cleanup()
-			if _, err := os.Stat(baseDir); !os.IsNotExist(err) {
-				t.Fatalf("expected not exist error: %v", err)
 			}
 		})
 	}

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -361,7 +361,7 @@ func (w *TODOWalker) gitRepo(path string) (*git.Repository, string, error) {
 
 	for {
 		gitPath := filepath.Join(path, ".git")
-		_, err := os.Stat(gitPath)
+		_, err = os.Stat(gitPath)
 		if err == nil {
 			break
 		}

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -433,6 +433,7 @@ func (w *TODOWalker) gitUser(
 		return nil, nil, nil, nil
 	}
 
+	// Attempt to fin the repo.
 	var repoRoot string
 	var err error
 	if r == nil {
@@ -440,6 +441,10 @@ func (w *TODOWalker) gitUser(
 		if err != nil {
 			return nil, nil, nil, err
 		}
+	}
+	// Return early if the file is not in a git repo.
+	if r == nil {
+		return nil, nil, nil, nil
 	}
 
 	if br == nil {

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -411,7 +411,8 @@ func (w *TODOWalker) gitBlame(r *git.Repository, repoRoot, path string) (*git.Bl
 		return nil, fmt.Errorf("%w: getting commit object for hash %s, %w", errGit, hash, err)
 	}
 
-	br, err := git.Blame(c, relPath)
+	// NOTE: git.Blame only supports paths with slash.
+	br, err := git.Blame(c, filepath.ToSlash(relPath))
 	if err != nil {
 		// Ignore files that aren't checked in.
 		if errors.Is(err, object.ErrFileNotFound) {

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -1353,7 +1353,7 @@ func TestTODOWalker_gitSubDir(t *testing.T) {
 			},
 		},
 		{
-			FileName: "path/to/repo/repo_file.go",
+			FileName: filepath.Join("path", "to", "repo", "repo_file.go"),
 			TODO: &todos.TODO{
 				Type:        "TODO",
 				Text:        "// TODO: some task.",


### PR DESCRIPTION
**Description:**

Fix the relative path passed to `git.Blame` to be relative to the git repository root.

**Related Issues:**

Fixes #1518 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
