### PR TITLE
feat: --label GLOB filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A new `--label` flag was added to support filtering TODOs by label
+  ([#1562](https://github.com/ianlewis/todos/issues/1562)).
 - Support was added for
   [MATLAB](https://www.mathworks.com/products/matlab.html)
 - Support was added for
@@ -33,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where TODOs were not being reported if they were located after a
   multi-line comment with no TODOs in the same file
-  ([#1520](https://github.com/ianlewis/todos/issues/1520))
+  ([#1520](https://github.com/ianlewis/todos/issues/1520)).
 
 ## [0.8.0] - 2024-02-21
 

--- a/internal/cmd/todos/app_test.go
+++ b/internal/cmd/todos/app_test.go
@@ -531,6 +531,18 @@ func Test_walkerOptionsFromContext(t *testing.T) {
 			args: []string{"--charset=invalid"},
 			err:  ErrFlagParse,
 		},
+		"label": {
+			args: []string{"--label=foo", "--label=bar-*"},
+			expected: &walker.Options{
+				Config: &todos.Config{
+					Types: todos.DefaultTypes,
+				},
+				LabelGlobs:    []glob.Glob{glob.MustCompile("foo"), glob.MustCompile("bar-*")},
+				Charset:       defaultCharset,
+				IncludeHidden: true,
+				Paths:         []string{"."},
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -316,7 +316,6 @@ func (w *TODOWalker) scanFile(f *os.File, force bool) error {
 		return nil
 	}
 	t := todos.NewTODOScanner(s, w.options.Config)
-scanL:
 	for t.Scan() {
 		todo := t.Next()
 
@@ -330,7 +329,7 @@ scanL:
 				}
 			}
 			if !labelMatch {
-				continue scanL
+				continue
 			}
 		}
 

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -946,6 +946,60 @@ var testCases = []testCase{
 			},
 		},
 	},
+	{
+		name: "label glob filter",
+		files: []*testutils.File{
+			{
+				Path: "line_comments.go",
+				Contents: []byte(`package foo
+				// package comment
+
+				// TODO: no label
+				// TODO(no-match): no match
+
+				// TODO is a function.
+				// TODO(todo-label): some task.
+				func TODO() {
+					return // TODO(other-label): Return comment
+				}`),
+				Mode: 0o600,
+			},
+		},
+		opts: &Options{
+			Config: &todos.Config{
+				Types: []string{"TODO"},
+			},
+			LabelGlobs: []glob.Glob{
+				glob.MustCompile("todo-*"),
+				glob.MustCompile("other-*"),
+			},
+			Charset: "UTF-8",
+		},
+		expected: []*TODORef{
+			{
+				FileName: "line_comments.go",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "// TODO(todo-label): some task.",
+					Message:     "some task.",
+					Label:       "todo-label",
+					Line:        8,
+					CommentLine: 8,
+				},
+			},
+			{
+				FileName: "line_comments.go",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "// TODO(other-label): Return comment",
+					Message:     "Return comment",
+					Label:       "other-label",
+					Line:        10,
+					CommentLine: 10,
+				},
+			},
+		},
+	},
 }
 
 type blameTestCase struct {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

A new `--label` flag is added that takes a GLOB and matches against TODO labels. The flag can be included multilpe times. A TODO that matches any label is included in the output.

**Related Issues:**

Fixes #1562

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
