### PR TITLE
fix: Remove deprecated exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,13 +37,14 @@ linters:
     # Some linters have been removed because of the go 1.18 issues.
     # https://github.com/golangci/golangci-lint/issues/2649
     - asciicheck
+    - contextcheck
+    - copyloopvar
     - depguard
     - dogsled
     - err113
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - gci
     - gochecknoinits
     - gocognit


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Replace the deprecated `exportloopref` linter with the `copyloopref` linter. Also enable the `contextcheck` linter.

**Related Issues:**

N/A

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [ ] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
