### PR TITLE
chore(deps): Bump sigs.k8s.io/release-utils from 0.8.4 to 0.8.5

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -128,8 +128,8 @@ jobs:
         with:
           go-version-file: "go.mod"
       - env:
-          GOLANGCI_LINT_VERSION: "1.59.1"
-          GOLANGCI_LINT_CHECKSUM: "c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791"
+          GOLANGCI_LINT_VERSION: "1.61.0"
+          GOLANGCI_LINT_CHECKSUM: "77cb0af99379d9a21d5dc8c38364d060e864a01bd2f3e30b5e8cc550c3a54111"
         run: |
           set -euo pipefail
 

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ golangci-lint: ## Runs the golangci-lint linter.
 	@set -e;\
 		extraargs=""; \
 		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
-			extraargs="--out-format github-actions"; \
+			extraargs="--out-format colored-line-number"; \
 		fi; \
 		golangci-lint run -c .golangci.yml ./... $$extraargs
 

--- a/Makefile
+++ b/Makefile
@@ -137,12 +137,7 @@ markdownlint: node_modules/.installed ## Runs the markdownlint linter.
 
 .PHONY: golangci-lint
 golangci-lint: ## Runs the golangci-lint linter.
-	@set -e;\
-		extraargs=""; \
-		if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
-			extraargs="--out-format colored-line-number"; \
-		fi; \
-		golangci-lint run -c .golangci.yml ./... $$extraargs
+	@golangci-lint run -c .golangci.yml ./...
 
 .PHONY: yamllint
 yamllint: ## Runs the yamllint linter.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ianlewis/todos
 
-go 1.21
+go 1.23
 
-toolchain go1.22.5
+toolchain go1.23.2
 
 require (
 	github.com/fatih/color v1.17.0
@@ -15,7 +15,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.4
 	golang.org/x/text v0.19.0
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
-	sigs.k8s.io/release-utils v0.8.4
+	sigs.k8s.io/release-utils v0.8.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -186,5 +186,5 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-sigs.k8s.io/release-utils v0.8.4 h1:4QVr3UgbyY/d9p74LBhg0njSVQofUsAZqYOzVZBhdBw=
-sigs.k8s.io/release-utils v0.8.4/go.mod h1:m1bHfscTemQp+z+pLCZnkXih9n0+WukIUU70n6nFnU0=
+sigs.k8s.io/release-utils v0.8.5 h1:FUtFqEAN621gSXv0L7kHyWruBeS7TUU9aWf76olX7uQ=
+sigs.k8s.io/release-utils v0.8.5/go.mod h1:qsm5bdxdgoHkD8HsXpgme2/c3mdsNaiV53Sz2HmKeJA=

--- a/internal/cmd/todos/app_test.go
+++ b/internal/cmd/todos/app_test.go
@@ -194,7 +194,6 @@ func Test_outCLI(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -258,7 +257,6 @@ func Test_outGithub(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -337,7 +335,6 @@ func Test_outJSON(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -546,7 +543,6 @@ func Test_walkerOptionsFromContext(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/testutils/gitrepo_test.go
+++ b/internal/testutils/gitrepo_test.go
@@ -132,7 +132,6 @@ func TestTempRepo(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/testutils/tempdir_test.go
+++ b/internal/testutils/tempdir_test.go
@@ -103,7 +103,6 @@ func TestTempDir(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -899,7 +899,6 @@ func TestTODOScanner(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/utils/slice_test.go
+++ b/internal/utils/slice_test.go
@@ -77,7 +77,6 @@ func TestSliceEqual_int(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got, want := SliceEqual(tc.l, tc.r), tc.equal; got != want {
@@ -148,7 +147,6 @@ func TestSliceEqual_rune(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got, want := SliceEqual(tc.l, tc.r), tc.equal; got != want {

--- a/internal/vendoring/vendoring_test.go
+++ b/internal/vendoring/vendoring_test.go
@@ -54,8 +54,6 @@ func TestIsVendor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

- Bump sigs.k8s.io/release-utils from 0.8.4 to 0.8.5
- Update golangci-lint to 1.61.0 to fix a memory leak issue.
- Use the default `colored-line-number` output format for golangci-lint because `github-actions` is now deprecated.
- Fix golangci-lint errors

**Related Issues:**

N/A

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
