### PR TITLE
feat: Add support for OCaml nested comments

### DIFF
--- a/internal/scanner/languages.go
+++ b/internal/scanner/languages.go
@@ -1,4 +1,5 @@
 // Copyright 2024 Google LLC
+// Copyright 2025 Ian Lewis
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -428,11 +429,12 @@ var LanguagesConfig = map[string]*Config{
 		Strings:           cStrings,
 	},
 	"OCaml": {
-		// TODO(#1627): Support OCaml nested comments.
 		MultilineComments: []MultilineCommentConfig{
 			{
 				Start: []rune("(*"),
 				End:   []rune("*)"),
+				// OCaml supports nested block comments.
+				Nested: true,
 			},
 		},
 		// TODO(#1627): Support OCaml quoted string literals.

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -2085,8 +2085,7 @@ This is more text.<!-- this is another comment -->
 		name: "comments.ml",
 		src: `(* single line comment *)
 
-(* multiple line comment, commenting out part of a program, and containing a
-nested comment:
+(* multiple line comment, commenting out part of a program:
 let f = function
   | 'A'..'Z' -> "Uppercase"
 *)`,
@@ -2100,8 +2099,7 @@ let f = function
 				line: 1,
 			},
 			{
-				text: `(* multiple line comment, commenting out part of a program, and containing a
-nested comment:
+				text: `(* multiple line comment, commenting out part of a program:
 let f = function
   | 'A'..'Z' -> "Uppercase"
 *)`,
@@ -2109,32 +2107,30 @@ let f = function
 			},
 		},
 	},
-
-	// TODO(#1627): Support OCaml nested comments.
-	// {
-	// 	name: "nested_comments.ml",
-	// 	src: `(* multiple line comment, commenting out part of a program, and containing a
-	// nested comment:
-	// let f = function
-	// | 'A'..'Z' -> "Uppercase"
-	// (* Add other cases later... *)
-	// *)`,
-	// 	config: "OCaml",
-	// 	comments: []struct {
-	// 		text string
-	// 		line int
-	// 	}{
-	// 		{
-	// 			text: `(* multiple line comment, commenting out part of a program, and containing a
-	// nested comment:
-	// let f = function
-	// | 'A'..'Z' -> "Uppercase"
-	// (* Add other cases later... *)
-	// *)`,
-	// 			line: 1,
-	// 		},
-	// 	},
-	// },
+	{
+		name: "nested_comments.ml",
+		src: `(* multiple line comment, commenting out part of a program, and containing a
+nested comment:
+let f = function
+  | 'A'..'Z' -> "Uppercase"
+(* Add other cases later... (* more nesting *) *)
+*)`,
+		config: "OCaml",
+		comments: []struct {
+			text string
+			line int
+		}{
+			{
+				text: `(* multiple line comment, commenting out part of a program, and containing a
+nested comment:
+let f = function
+  | 'A'..'Z' -> "Uppercase"
+(* Add other cases later... (* more nesting *) *)
+*)`,
+				line: 1,
+			},
+		},
+	},
 
 	// Python
 	{


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Add support for OCaml nested comments.

**Related Issues:**

Fixes #1628 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
