### PR TITLE
chore: use -mod=vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ node_modules/.installed: package.json package-lock.json
 
 .PHONY: build
 build: ## Build todos app.
-	go build github.com/ianlewis/todos/internal/cmd/todos
+	go build -mod=vendor github.com/ianlewis/todos/internal/cmd/todos
 
 .PHONY: build
 build-profile: ## Build todos app with profiling.
-	go build -tags profile github.com/ianlewis/todos/internal/cmd/todos
+	go build -mod=vendor -tags profile github.com/ianlewis/todos/internal/cmd/todos
 
 ## Testing
 #####################################################################


### PR DESCRIPTION
**Description:**

Add `-mod=vendor` option to the `build` and `build-profile` make targets.

**Related Issues:**

N/A

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
