### PR TITLE
chore: Use strings.SplitSeq

### DIFF
--- a/cmd/todos/app.go
+++ b/cmd/todos/app.go
@@ -393,7 +393,7 @@ func walkerOptionsFromContext(c *cli.Context) (*walker.Options, error) {
 
 	todoTypesStr := c.String("todo-types")
 	if todoTypesStr != "" {
-		for _, todoType := range strings.Split(todoTypesStr, ",") {
+		for todoType := range strings.SplitSeq(todoTypesStr, ",") {
 			o.Config.Types = append(o.Config.Types, strings.TrimSpace(todoType))
 		}
 	}

--- a/internal/todos/todos.go
+++ b/internal/todos/todos.go
@@ -168,7 +168,8 @@ func (t *TODOScanner) Scan() bool {
 // findMultilineMatch returns the TODO for the comment if it was found.
 func (t *TODOScanner) findMultilineMatches(c *scanner.Comment) []*TODO {
 	var matches []*TODO
-	for i, line := range strings.Split(strings.TrimSpace(c.Text), "\n") {
+	var i int
+	for line := range strings.SplitSeq(strings.TrimSpace(c.Text), "\n") {
 		lineText := strings.TrimLeft(line, string(c.MultilineConfig.Start))
 		lineText = strings.TrimRight(lineText, string(c.MultilineConfig.End))
 
@@ -194,6 +195,7 @@ func (t *TODOScanner) findMultilineMatches(c *scanner.Comment) []*TODO {
 				CommentLine: c.Line,
 			})
 		}
+		i++
 	}
 	return matches
 }


### PR DESCRIPTION
**Description:**

Use `strings.SplitSeq` because it's slightly more efficient.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
