### PR TITLE
chore: Don't use maintidx

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,7 @@ linters:
     # - ireturn # Accept Interfaces, Return Concrete Types.
     - lll # Reports long lines.
     - loggercheck # Checks key value pairs for common logger libraries (kitlog,klog,logr,zap).
-    # TODO(#1678): Enable maintidx linter.
+    # maintidx doesn't add much above using gocyclo, cyclop, and gocognit.
     # - maintidx # Maintidx measures the maintainability index of each function.
     - makezero # Finds slice declarations with non-zero initial length.
     - mirror # Reports wrong mirror patterns of bytes/strings usage.


### PR DESCRIPTION
**Description:**

Don't use `maintidx` since it doesn't provide much value in addition to `gocyclo`, `cyclop`, and `gocognit`.

**Related Issues:**

Updates #1678

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
