### PR TITLE
feat!: print an error for unsupported files

### DIFF
--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -328,6 +328,11 @@ func (w *TODOWalker) scanFile(f *os.File, force bool) error {
 	s, err := scanner.FromBytes(f.Name(), rawContents, w.options.Charset)
 	if errors.Is(err, scanner.ErrUnsupportedLanguage) || errors.Is(err, scanner.ErrBinaryFile) {
 		// Ignore unsupported languages and binary files.
+		if force {
+			// ...unless the file was explicitly specified in options.Paths.
+			//nolint:wrapcheck // error is for an explicitly specified file.
+			return err
+		}
 		return nil
 	}
 	if err != nil {

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -1255,6 +1255,25 @@ var testCases = []testCase{
 		},
 		expected: nil,
 	},
+	{
+		name: "unsupported files generate error if specified",
+		files: []*testutils.File{
+			{
+				Path:     "unsupported_lang.coq",
+				Contents: []byte{},
+				Mode:     0o600,
+			},
+		},
+		opts: &Options{
+			Config: &todos.Config{
+				Types: []string{"TODO"},
+			},
+			Charset: "UTF-8",
+			Paths:   []string{"unsupported_lang.coq"},
+		},
+		expected: nil,
+		err:      true,
+	},
 }
 
 type blameTestCase struct {
@@ -1297,6 +1316,7 @@ func init() {
 				files:    tc.files,
 				opts:     &opts,
 				expected: expected,
+				err:      tc.err,
 			},
 
 			author: author,


### PR DESCRIPTION
**Description:**

BREAKING CHANGE: Print an error for unsupported or binary files if they are explictly specified on the command line. This also causes `todos` to return a non-zero exit code. These files are ignored when walking a directory.

**Related Issues:**

Fixes #1668 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
