### PR TITLE
fix: renovate pin digest rules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,7 +41,10 @@
   packageRules: [
     {
       matchManagers: ["github-actions"],
-      matchPackageNames: ["slsa-framework/slsa-verifier/actions/installer"],
+      matchPackageNames: [
+        "slsa-framework/slsa-github-generator",
+        "slsa-framework/slsa-verifier",
+      ],
       pinDigests: false,
     },
     {


### PR DESCRIPTION
**Description:**

Fix the Renovate rules for pinning digests.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
