### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -20,6 +20,8 @@ on:
 
 permissions: {}
 
+concurrency: production
+
 env:
   IMAGE_REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -29,7 +31,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # To checkout the code.
     outputs:
       tag: ${{ steps.ldflags.outputs.tag }}
       version: ${{ steps.ldflags.outputs.version }}
@@ -101,8 +103,10 @@ jobs:
   npm-publish:
     needs: [validate, build-todos]
     runs-on: ubuntu-latest
+    environment: npm-production
     permissions:
-      id-token: write # To sign.
+      contents: read # Needed to checkout the repo.
+      id-token: write # Needed to sign provenance and publish to npm.
     steps:
       - id: checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -198,20 +202,23 @@ jobs:
           set -euo pipefail
 
           # Verify the provenance of the downloaded binaries.
-          for arch in amd64 arm64; do
-            artifact="todos-linux-${arch}"
-            provenance_file="${artifact}.intoto.jsonl"
-            slsa-verifier verify-artifact \
-              --builder-id "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml" \
-              --provenance-path "${provenance_file}" \
-              --source-uri "github.com/${GITHUB_REPOSITORY}" \
-              --source-tag "${TAG}" \
-              "${artifact}"
+          for os in linux darwin windows; do
+            for arch in amd64 arm64; do
+              artifact="todos-${os}-${arch}"
+              if [[ "${os}" == "windows" ]]; then
+                artifact="${artifact}.exe"
+              fi
+              provenance_file="${artifact}.intoto.jsonl"
+              slsa-verifier verify-artifact \
+                --builder-id "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml" \
+                --provenance-path "${provenance_file}" \
+                --source-uri "github.com/${GITHUB_REPOSITORY}" \
+                --source-tag "${TAG}" \
+                "${artifact}"
+            done
           done
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           set -euo pipefail
 

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -16,5 +16,5 @@ rules:
   unpinned-uses:
     ignore:
       # Allow unpinned use of the slsa-verifier installer action.
-      - go-ossf-slsa3-publish.yml:192:9
-      - go-ossf-slsa3-publish.yml:286:9
+      - go-ossf-slsa3-publish.yml:196:9
+      - go-ossf-slsa3-publish.yml:293:9


### PR DESCRIPTION
**Description:**

Use npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) for publishing to npm. This adds a new deployment environment with deployment rules. The `npm-publish` job will require manual approval to run.

**Related Issues:**

Fixes #1788 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
