### PR TITLE
docs: update CHANGELOG to note breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A new option `--follow` was added to specify whether `todos` should follow
-  symlinks when traversing directories.
+- BREAKING CHANGE: `todos` no longer follows symlinks by default. Symlinks will
+  be followed if the symlink is specified directly on the command line. A new
+  option `--follow` was added to specify whether `todos` should follow symlinks
+  when traversing directories.
   ([#1752](https://github.com/ianlewis/todos/issues/1752)).
 - Support was added for the [Svelte language](https://svelte.dev/)
   ([#1805](https://github.com/ianlewis/todos/issues/1805)).


### PR DESCRIPTION
**Description:**

Add note on the breaking change that `todos` will no longer follow symlinks by default when traversing directories.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
