### PR TITLE
Change Strings to doubleQuoteString for Rust language definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default TODO types were changed to add `FIXIT`, `ISSUE`, `WARN`, and
   `WARNING` ([#1747](https://github.com/ianlewis/todos/issues/1747)).
 
+### Fixed
+
+- In Rust sources (`.rs`, `.rs.in`), now only double quotes (`"`) are
+  interpreted as string termination characters. This fixes cases where `TODO`s
+  in files with lifetime specifiers (e.g. `&'static str`) would not be parsed
+  as expected.
+  ([#1829](https://github.com/ianlewis/todos/issues/1829)).
+
 ## [`0.13.0`] - 2025-05-18
 
 ### Added in `0.13.0`

--- a/internal/scanner/languages.go
+++ b/internal/scanner/languages.go
@@ -1,5 +1,5 @@
 // Copyright 2024 Google LLC
-// Copyright 2025 Ian Lewis, Marcin Wiśniowski
+// Copyright 2025 Ian Lewis, Marcin Wiśniowski, Steffen Raabe
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -617,7 +617,7 @@ var LanguagesConfig = map[string]*Config{
 	"Rust": {
 		LineComments:      cLineComments,
 		MultilineComments: cBlockComments,
-		Strings:           cStrings,
+		Strings:           doubleQuoteString,
 	},
 	"SQL": {
 		LineComments: []LineCommentConfig{

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Google LLC
-// Copyright 2025 Ian Lewis, Marcin Wiśniowski
+// Copyright 2025 Ian Lewis, Marcin Wiśniowski, Steffen Raabe
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2574,8 +2574,7 @@ TODO is a function.
 			// TODO is a function.
 			fn TODO() {
 				let x: String = "// Random comment";
-				let y: String = '// Random comment';
-				x + y
+				x
 			}`,
 		config: "Rust",
 		comments: []struct {
@@ -2599,8 +2598,7 @@ TODO is a function.
 			// TODO is a function.
 			fn TODO() {
 				let x: String "\"// Random comment";
-				let y: String '\'// Random comment';
-				x + y
+				x
 			}`,
 		config: "Rust",
 		comments: []struct {
@@ -2628,8 +2626,7 @@ TODO is a function.
 			fn TODO() -> String {
 				// Random comment
 				let x: String = "\"// Random comment";
-				let y: String = '\'// Random comment';
-				x + y
+				x
 			}`,
 		config: "Rust",
 		comments: []struct {
@@ -2643,6 +2640,34 @@ TODO is a function.
 			{
 				text: "// Random comment",
 				line: 8,
+			},
+		},
+	},
+	{
+		name: "lifetime_specifier.rs",
+		src: `// file comment
+
+			const A: &'static str = "some string";
+			// another file comment
+			const B: &'static str = "some other string";
+
+			// yet another file comment`,
+		config: "Rust",
+		comments: []struct {
+			text string
+			line int
+		}{
+			{
+				text: "// file comment",
+				line: 1,
+			},
+			{
+				text: "// another file comment",
+				line: 4,
+			},
+			{
+				text: "// yet another file comment",
+				line: 7,
 			},
 		},
 	},


### PR DESCRIPTION
**Description:**
See Issue #1829 for details.
Proposed fix is to use double-quotes only for Rust strings as single-quotes only indicate single characters anyway and thus couldn't contain a TODO in any valid Rust source file.

Changelog should not be required because this only restores expected behavior.


**Related Issues:**
#1829

<!-- Add related issue references -->
<!-- You are strongly encouraged to create an issue for any change to allow for
discussion on the proposed change before actually making the changes and
proposing them via a Pull Request. -->
</br></br>
**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
