### PR TITLE
fix: incorrect TODOs with hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In Rust sources (`.rs`, `.rs.in`), now only double quotes (`"`) are
   interpreted as string termination characters. This fixes cases where `TODO`s
-  in files with lifetime specifiers (e.g. `&'static str`) would not be parsed
-  as expected.
-  ([#1829](https://github.com/ianlewis/todos/issues/1829)).
+  in files with lifetime specifiers (e.g. `&'static str`) would not be parsed as
+  expected. ([#1829](https://github.com/ianlewis/todos/issues/1829)).
+- Fixed an issue where some comments were interpreted incorrectly as TODOs when
+  the TODO type was followed directly by a hyphen (`-`) without a space (e.g.
+  `// Info-level logging`)
+  ([#1816](https://github.com/ianlewis/todos/issues/1816)
 
 ## [`0.13.0`] - 2025-05-18
 

--- a/internal/todos/todos_test.go
+++ b/internal/todos/todos_test.go
@@ -1170,6 +1170,25 @@ func TestTODOScanner(t *testing.T) {
 				},
 			},
 		},
+
+		// Regression test for issue #1816
+		"regression_1816.lua": {
+			s: &testScanner{
+				comments: []*scanner.Comment{
+					{
+						Text: "-- Info-level todos (NOTE, INFO, PERF, OPTIMIZE, TEST)",
+						Line: 1,
+						LineConfig: &scanner.LineCommentConfig{
+							Start: []rune("--"),
+						},
+					},
+				},
+			},
+			config: &Config{
+				Types: []string{"Info"},
+			},
+			expected: nil,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
**Description:**

Fixed an issue where some comments were interpreted incorrectly as TODOs when the TODO type was followed directly by a hyphen (`-`) without a space (e.g. `// Info-level logging`)

**Related Issues:**

Fixes #1816 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
