### PR TITLE
feat: add generic fallback configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -419,6 +419,7 @@ linters:
             - "github.com/ianlewis/todos"
 
             # Dependencies.
+            - "github.com/go-enry/go-enry/v2"
             - "github.com/gobwas/glob"
             - "github.com/google/go-cmp/cmp"
             - "github.com/google/go-github"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -419,7 +419,6 @@ linters:
             - "github.com/ianlewis/todos"
 
             # Dependencies.
-            - "github.com/go-enry/go-enry/v2"
             - "github.com/gobwas/glob"
             - "github.com/google/go-cmp/cmp"
             - "github.com/google/go-github"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support was added for reading from standard input with the '-' filename
   ([#1782](https://github.com/ianlewis/todos/issues/1782)).
 
+### Changed
+
+- If a file is detected to be a programming or markup language but is
+  unsupported, `todos` will use a generic fallback configuration that supports
+  C-style comments, shell (hash) comments, and XML/HTML comments
+  ([#1208](https://github.com/ianlewis/todos/issues/1208)).
+
 ## [`0.14.0`] - 2025-12-20
 
 ### Added in `0.14.0`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Be aware though that there are a few downsides to using the Go tools approach.
 ## 📖 Usage
 
 Simply running `todos` will search TODO comments starting in the current
-directory.Here is an example running in a checkout of the
+directory. Here is an example running in a checkout of the
 [`Kubernetes`](https://github.com/kubernetes/kubernetes) codebase.
 
 ```shell
@@ -158,6 +158,10 @@ file.
 
 See [`SUPPORTED_LANGUAGES.md`] for a full list of supported languages and
 comment types.
+
+If a file is detected to be a programming or markup language file but is
+as-of-yet unsupported, `todos` will parse it using a generic configuration that
+supports C-style comments, shell (hash) comments, and XML/HTML comments.
 
 ### TODO format
 
@@ -193,7 +197,7 @@ There a few variants of this type of comment that are in wide use.
 - **`BUG`**: A bug in the code that needs to be fixed.
 - **`HACK`**: This code is a "hack"; a hard to understand or brittle piece of
   code. It could use a cleanup.
-- **`XXX`**: Danger! Similar to "HACK". Modifying this code is dangerous. It
+- **`XXX`**: Danger! Similar to "HACK". Modifying this code is dangerous.
 - **`COMBAK`**: Something you should "come back" to.
 
 `TODO`,`FIXME`,`BUG`,`HACK`,`XXX`,`COMBAK` are supported by default. You can

--- a/cmd/todos/app.go
+++ b/cmd/todos/app.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/text/encoding/ianaindex"
 	"sigs.k8s.io/release-utils/version"
 
+	"github.com/ianlewis/todos/internal/scanner"
 	"github.com/ianlewis/todos/internal/todos"
 	"github.com/ianlewis/todos/internal/utils"
 	"github.com/ianlewis/todos/internal/walker"
@@ -352,9 +353,9 @@ var outTypes = map[string]func(io.Writer) walker.TODOHandler{
 func walkerOptionsFromContext(cliCtx *cli.Context) (*walker.Options, error) {
 	opts := walker.Options{}
 
-	// Valdidate the character set.
+	// Validate the character set.
 	charset := cliCtx.String("charset")
-	if charset != "detect" {
+	if charset != scanner.DetectCharset {
 		if charset == "ISO-8859-1" {
 			charset = "UTF-8"
 		}

--- a/internal/cmd/genlangdocs/main.go
+++ b/internal/cmd/genlangdocs/main.go
@@ -73,7 +73,7 @@ func main() {
 	fmt.Println("")
 	fmt.Println("# Supported Languages")
 	fmt.Println("")
-	fmt.Printf("%d languages are currently supported.\n", len(scanner.LanguagesConfig))
+	fmt.Printf("%d languages are currently supported.\n", len(langs))
 	fmt.Println("")
 
 	fmt.Println("| Language | Files | Supported comments |")

--- a/internal/cmd/genlangdocs/main.go
+++ b/internal/cmd/genlangdocs/main.go
@@ -51,7 +51,7 @@ func main() {
 	langs := langConfigs(make([]langConfig, 0, len(scanner.LanguagesConfig)))
 
 	for lang, config := range scanner.LanguagesConfig {
-		if lang == enry.OtherLanguage {
+		if lang == scanner.GenericLanguage {
 			continue
 		}
 

--- a/internal/cmd/genlangdocs/main.go
+++ b/internal/cmd/genlangdocs/main.go
@@ -51,6 +51,10 @@ func main() {
 	langs := langConfigs(make([]langConfig, 0, len(scanner.LanguagesConfig)))
 
 	for lang, config := range scanner.LanguagesConfig {
+		if lang == enry.OtherLanguage {
+			continue
+		}
+
 		info, err := enry.GetLanguageInfo(lang)
 		if err != nil {
 			panic(err)

--- a/internal/scanner/languages.go
+++ b/internal/scanner/languages.go
@@ -15,6 +15,8 @@
 
 package scanner
 
+import "github.com/go-enry/go-enry/v2"
+
 // Common config.
 
 func concat[T any](slices ...[]T) []T {
@@ -151,6 +153,17 @@ var (
 //
 //nolint:gochecknoglobals // remove in the future.
 var LanguagesConfig = map[string]*Config{
+	enry.OtherLanguage: { // Unknown language
+		LineComments: concat(
+			cLineComments,
+			hashLineComments,
+		),
+		MultilineComments: concat(
+			cBlockComments,
+			xmlBlockComments,
+		),
+		Strings: cStrings,
+	},
 	"Assembly": {
 		LineComments:      iniLineComments,
 		MultilineComments: cBlockComments,

--- a/internal/scanner/languages.go
+++ b/internal/scanner/languages.go
@@ -15,8 +15,6 @@
 
 package scanner
 
-import "github.com/go-enry/go-enry/v2"
-
 // Common config.
 
 func concat[T any](slices ...[]T) []T {
@@ -35,6 +33,9 @@ func concat[T any](slices ...[]T) []T {
 
 	return newS
 }
+
+// GenericLanguage specifies a genric language configuration.
+const GenericLanguage = "<generic>"
 
 // TODO(#1686): Refactor language config global variables.
 //
@@ -153,7 +154,7 @@ var (
 //
 //nolint:gochecknoglobals // remove in the future.
 var LanguagesConfig = map[string]*Config{
-	enry.OtherLanguage: { // Unknown language
+	GenericLanguage: { // Unknown language
 		LineComments: concat(
 			cLineComments,
 			hashLineComments,

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -166,12 +166,11 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 			return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
 		}
 	} else {
+		// Detect the language from the filename and contents.
 		lang = enry.GetLanguage(fileName, decodedContents)
-	}
-
-	// If the language was not detected at this point then it is unsupported.
-	if lang == enry.OtherLanguage {
-		return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
+		if lang == enry.OtherLanguage {
+			return nil, fmt.Errorf("%w: unknown language", ErrUnsupportedLanguage)
+		}
 	}
 
 	// Extract the language configuration.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -169,6 +169,11 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 		lang = enry.GetLanguage(fileName, decodedContents)
 	}
 
+	// If the language was not detected at this point then it is unsupported.
+	if lang == enry.OtherLanguage {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
+	}
+
 	// Extract the language configuration.
 	config, ok := LanguagesConfig[lang]
 	if !ok {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -184,7 +184,7 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 			return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
 		}
 
-		config = LanguagesConfig[enry.OtherLanguage]
+		config = LanguagesConfig[GenericLanguage]
 	}
 
 	return New(bytes.NewReader(decodedContents), config), nil

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -53,7 +53,7 @@ var (
 
 // DetectCharset is a special character set indicating that the actual
 // character set should be detected from the file contents.
-var DetectCharset = "detect"
+const DetectCharset = "detect"
 
 // StringConfig is a configuration for a string literal.
 type StringConfig struct {
@@ -174,10 +174,11 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 	if !ok {
 		// Fall back to generic handling for programming or markup languages.
 		langType := enry.GetLanguageType(lang)
-		fmt.Println(fileName, langType)
+
 		if langType != enry.Programming && langType != enry.Markup {
 			return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
 		}
+
 		config = LanguagesConfig[enry.OtherLanguage]
 	}
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -141,7 +141,7 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 		charset = "GB18030"
 	}
 
-	// Detect the language encoding.
+	// Look up the character-set encoding.
 	e, err := ianaindex.IANA.Encoding(charset)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s: %w", errDecodeCharset, charset, err)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -51,6 +51,10 @@ var (
 	ErrBinaryFile = errors.New("binary file")
 )
 
+// DetectCharset is a special character set indicating that the actual
+// character set should be detected from the file contents.
+var DetectCharset = "detect"
+
 // StringConfig is a configuration for a string literal.
 type StringConfig struct {
 	// Start is the starting sequence for the string literal.
@@ -115,7 +119,7 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 		return nil, ErrBinaryFile
 	}
 
-	if charset == "detect" {
+	if charset == DetectCharset {
 		// Detect the character set.
 		det := chardet.NewTextDetector()
 
@@ -137,6 +141,7 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 		charset = "GB18030"
 	}
 
+	// Detect the language encoding.
 	e, err := ianaindex.IANA.Encoding(charset)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s: %w", errDecodeCharset, charset, err)
@@ -152,20 +157,28 @@ func FromBytes(fileName string, rawContents []byte, lang, charset string) (*Comm
 	}
 
 	// Detect the programming language.
+	var found bool
 	if lang != "" {
-		lang, _ = enry.GetLanguageByAlias(lang)
+		lang, found = enry.GetLanguageByAlias(lang)
+		if !found {
+			// If the language was specified but isn't supported then return an
+			// error.
+			return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
+		}
 	} else {
 		lang = enry.GetLanguage(fileName, decodedContents)
 	}
 
-	if lang == enry.OtherLanguage {
-		return nil, fmt.Errorf("%w: %s: language could not be detected", ErrUnsupportedLanguage, fileName)
-	}
-
-	// Detect the language encoding.
+	// Extract the language configuration.
 	config, ok := LanguagesConfig[lang]
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrUnsupportedLanguage, lang)
+		// Fall back to generic handling for programming or markup languages.
+		langType := enry.GetLanguageType(lang)
+		fmt.Println(fileName, langType)
+		if langType != enry.Programming && langType != enry.Markup {
+			return nil, fmt.Errorf("%w: %q", ErrUnsupportedLanguage, lang)
+		}
+		config = LanguagesConfig[enry.OtherLanguage]
 	}
 
 	return New(bytes.NewReader(decodedContents), config), nil

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-enry/go-enry/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/text/encoding/ianaindex"
@@ -3844,11 +3845,16 @@ let () = print_endline "hello world"
 	//	expectedConfig: "Go",
 	// },
 	{
-		name:           "unsupported_lang.coq",
+		name:           "fallback.coq", // .coq is the Rocq prover
 		src:            []byte{},
 		scanCharset:    "UTF-8",
-		expectedConfig: "", // nil
-		err:            ErrUnsupportedLanguage,
+		expectedConfig: enry.OtherLanguage, // Other language
+	},
+	{
+		name:        "unsupported.txt", // .txt is prose.
+		src:         []byte{},
+		scanCharset: "UTF-8",
+		err:         ErrUnsupportedLanguage,
 	},
 	{
 		name: "typescript_is_not_xml.ts",
@@ -3963,13 +3969,11 @@ func TestFromFile(t *testing.T) {
 				t.Fatalf("FromFile: unexpected err (-want +got):\n%s", diff)
 			}
 
-			var config *Config
 			if s != nil {
-				config = s.Config()
-			}
-
-			if got, want := config, LanguagesConfig[testCase.expectedConfig]; got != want {
-				t.Fatalf("unexpected config, got: %#v, want: %#v", got, want)
+				config := s.Config()
+				if got, want := config, LanguagesConfig[testCase.expectedConfig]; got != want {
+					t.Fatalf("unexpected config, got: %#v, want: %#v", got, want)
+				}
 			}
 		})
 	}
@@ -3999,13 +4003,11 @@ func TestFromBytes(t *testing.T) {
 				t.Fatalf("FromBytes: unexpected err (-want +got):\n%s", diff)
 			}
 
-			var config *Config
 			if s != nil {
-				config = s.Config()
-			}
-
-			if got, want := config, LanguagesConfig[tc.expectedConfig]; got != want {
-				t.Fatalf("unexpected LanguagesConfig, got: %#v, want: %#v", got, want)
+				config := s.Config()
+				if got, want := config, LanguagesConfig[tc.expectedConfig]; got != want {
+					t.Fatalf("unexpected LanguagesConfig, got: %#v, want: %#v", got, want)
+				}
 			}
 		})
 	}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3851,9 +3851,29 @@ let () = print_endline "hello world"
 		expectedConfig: enry.OtherLanguage, // Other language
 	},
 	{
-		name:        "unsupported.txt", // .txt is prose.
+		name:        "unsupported_lang_unspecified.txt", // .txt is prose.
 		src:         []byte{},
 		scanCharset: "UTF-8",
+		err:         ErrUnsupportedLanguage,
+	},
+	{
+		name:        "undetected_lang_unspecified",
+		src:         []byte{},
+		scanCharset: "UTF-8",
+		err:         ErrUnsupportedLanguage,
+	},
+	{
+		name:        "unsupported_lang_specified",
+		src:         []byte{},
+		scanCharset: "UTF-8",
+		lang:        "Text",
+		err:         ErrUnsupportedLanguage,
+	},
+	{
+		name:        "unknown_lang_specified",
+		src:         []byte{},
+		scanCharset: "UTF-8",
+		lang:        "<unsupported language>",
 		err:         ErrUnsupportedLanguage,
 	},
 	{

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-enry/go-enry/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/text/encoding/ianaindex"
@@ -3848,7 +3847,7 @@ let () = print_endline "hello world"
 		name:           "fallback.coq", // .coq is the Rocq prover
 		src:            []byte{},
 		scanCharset:    "UTF-8",
-		expectedConfig: enry.OtherLanguage, // Other language
+		expectedConfig: GenericLanguage, // Other language
 	},
 	{
 		name:        "unsupported_lang_unspecified.txt", // .txt is prose.
@@ -3989,11 +3988,13 @@ func TestFromFile(t *testing.T) {
 				t.Fatalf("FromFile: unexpected err (-want +got):\n%s", diff)
 			}
 
+			var config *Config
 			if s != nil {
-				config := s.Config()
-				if got, want := config, LanguagesConfig[testCase.expectedConfig]; got != want {
-					t.Fatalf("unexpected config, got: %#v, want: %#v", got, want)
-				}
+				config = s.Config()
+			}
+
+			if got, want := config, LanguagesConfig[testCase.expectedConfig]; got != want {
+				t.Fatalf("unexpected config, got: %#v, want: %#v", got, want)
 			}
 		})
 	}
@@ -4023,11 +4024,13 @@ func TestFromBytes(t *testing.T) {
 				t.Fatalf("FromBytes: unexpected err (-want +got):\n%s", diff)
 			}
 
+			var config *Config
 			if s != nil {
-				config := s.Config()
-				if got, want := config, LanguagesConfig[tc.expectedConfig]; got != want {
-					t.Fatalf("unexpected LanguagesConfig, got: %#v, want: %#v", got, want)
-				}
+				config = s.Config()
+			}
+
+			if got, want := config, LanguagesConfig[tc.expectedConfig]; got != want {
+				t.Fatalf("unexpected LanguagesConfig, got: %#v, want: %#v", got, want)
 			}
 		})
 	}

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -1223,7 +1223,6 @@ var testCases = []testCase{
 			Charset:         "UTF-8",
 		},
 		expected: nil,
-		// expected: []*TODORef{},
 	},
 	{
 		name: "binary files are ignored",
@@ -1243,29 +1242,21 @@ var testCases = []testCase{
 		expected: nil,
 	},
 	{
-		name: "unsupported files are ignored",
+		name: "unsupported files fallback to generic config",
 		files: []*testutils.File{
 			{
-				Path:     "unsupported_lang.coq",
-				Contents: []byte{},
-				Mode:     0o600,
-			},
-		},
-		opts: &Options{
-			Config: &todos.Config{
-				Types: []string{"TODO"},
-			},
-			Charset: "UTF-8",
-		},
-		expected: nil,
-	},
-	{
-		name: "unsupported files generate error if specified",
-		files: []*testutils.File{
-			{
-				Path:     "unsupported_lang.coq",
-				Contents: []byte{},
-				Mode:     0o600,
+				Path: "unsupported_lang.coq",
+				Contents: []byte(`package foo
+				# TODO: hash comments
+
+				<!-- TODO: XML comment -->
+
+				// TODO is a function.
+				// TODO: some task.
+				func TODO() {
+					return /* TODO: C block comment */
+				}`),
+				Mode: 0o600,
 			},
 		},
 		opts: &Options{
@@ -1273,7 +1264,69 @@ var testCases = []testCase{
 				Types: []string{"TODO"},
 			},
 			Charset:            "UTF-8",
-			Paths:              []string{"unsupported_lang.coq"},
+			ErrorOnUnsupported: true,
+		},
+		expected: []*TODORef{
+			{
+				FileName: "unsupported_lang.coq",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "# TODO: hash comments",
+					Message:     "hash comments",
+					Line:        2,
+					CommentLine: 2,
+				},
+			},
+			{
+				FileName: "unsupported_lang.coq",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "<!-- TODO: XML comment -->",
+					Message:     "XML comment",
+					Line:        4,
+					CommentLine: 4,
+				},
+			},
+			{
+				FileName: "unsupported_lang.coq",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "// TODO: some task.",
+					Message:     "some task.",
+					Line:        7,
+					CommentLine: 7,
+				},
+			},
+			{
+				FileName: "unsupported_lang.coq",
+				TODO: &todos.TODO{
+					Type:        "TODO",
+					Text:        "/* TODO: C block comment */",
+					Message:     "C block comment",
+					Line:        9,
+					CommentLine: 9,
+				},
+			},
+		},
+	},
+	{
+		name: "unsupported files generate ErrorUnsupportedLanguage if specified",
+		files: []*testutils.File{
+			{
+				Path: "unsupported.txt",
+				Contents: []byte(`// TODO is a function.
+				// TODO: some task.
+
+				Text is prose.`),
+				Mode: 0o600,
+			},
+		},
+		opts: &Options{
+			Config: &todos.Config{
+				Types: []string{"TODO"},
+			},
+			Charset:            "UTF-8",
+			Paths:              []string{"unsupported.txt"},
 			ErrorOnUnsupported: true,
 		},
 		expected: nil,
@@ -1283,9 +1336,12 @@ var testCases = []testCase{
 		name: "unsupported files don't generate error if ErrorOnUnsupported is false",
 		files: []*testutils.File{
 			{
-				Path:     "unsupported_lang.coq",
-				Contents: []byte{},
-				Mode:     0o600,
+				Path: "unsupported.txt",
+				Contents: []byte(`// TODO is a function.
+				// TODO: some task.
+
+				Text is prose.`),
+				Mode: 0o600,
 			},
 		},
 		opts: &Options{
@@ -1293,7 +1349,7 @@ var testCases = []testCase{
 				Types: []string{"TODO"},
 			},
 			Charset:            "UTF-8",
-			Paths:              []string{"unsupported_lang.coq"},
+			Paths:              []string{"unsupported.txt"},
 			ErrorOnUnsupported: false,
 		},
 		expected: nil,


### PR DESCRIPTION
**Description:**

Add a generic fallback configuration when a file is detected to be a programming or markup language but is as-of-yet unsupported.

**Related Issues:**

- #1208

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
